### PR TITLE
xtensa: switch to little endianness

### DIFF
--- a/target-xtensa.c
+++ b/target-xtensa.c
@@ -22,7 +22,7 @@ static void predefine_xtensa(const struct target *self)
 const struct target target_xtensa = {
 	.mach = MACH_XTENSA,
 	.bitness = ARCH_LP32,
-	.big_endian = true,
+	.big_endian = false,
 
 	.bits_in_longdouble = 64,
 


### PR DESCRIPTION
Current gcc options only support the little endian mode on Xtensa, switch over to it.
